### PR TITLE
Device location and Path Tab

### DIFF
--- a/app/PathMapper/PathMapper/PathMapper.Droid/CustomMapRenderer.cs
+++ b/app/PathMapper/PathMapper/PathMapper.Droid/CustomMapRenderer.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using Android.Gms.Maps;
+using Android.Gms.Maps.Model;
+using Xamarin.Forms;
+using Xamarin.Forms.Maps;
+using Xamarin.Forms.Maps.Android;
+using PathMapper;
+using PathMapper.Droid;
+
+[assembly: ExportRenderer(typeof(CustomMap), typeof(CustomMapRenderer))]
+namespace PathMapper.Droid
+{
+    public class CustomMapRenderer : MapRenderer, IOnMapReadyCallback
+    {
+        GoogleMap map;
+        List<Position> routeCoordinates;
+
+        protected override void OnElementChanged (Xamarin.Forms.Platform.Android.ElementChangedEventArgs<View> e)
+        {
+            base.OnElementChanged(e);
+
+            if (e.OldElement != null)
+            {
+                // Unsubscribe
+            }
+
+            if (e.NewElement != null)
+            {
+                var formsMap = (CustomMap)e.NewElement;
+                routeCoordinates = formsMap.PathCoordinates;
+
+                ((MapView)Control).GetMapAsync(this);
+            }
+        }
+
+        public void OnMapReady(GoogleMap googleMap)
+        {
+            map = googleMap;
+
+            var polylineOptions = new PolylineOptions();
+            polylineOptions.InvokeColor(0x66FF0000);
+
+            foreach (var position in routeCoordinates)
+            {
+                polylineOptions.Add(new LatLng(position.Latitude, position.Longitude));
+            }
+
+            map.AddPolyline(polylineOptions);
+        }
+    }
+
+}

--- a/app/PathMapper/PathMapper/PathMapper.Droid/PathMapper.Droid.csproj
+++ b/app/PathMapper/PathMapper/PathMapper.Droid/PathMapper.Droid.csproj
@@ -128,6 +128,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomMapRenderer.cs" />
     <Compile Include="MainActivity.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/app/PathMapper/PathMapper/PathMapper/App.cs
+++ b/app/PathMapper/PathMapper/PathMapper/App.cs
@@ -15,6 +15,7 @@ namespace PathMapper
 
             // demonstrates the map control with zooming and map-types
             tabs.Children.Add(new MapPage { Title = "Map" });
+            tabs.Children.Add(new OverlayPath { Title = "Path" });
 
             MainPage = tabs;
         }

--- a/app/PathMapper/PathMapper/PathMapper/CustomMap.cs
+++ b/app/PathMapper/PathMapper/PathMapper/CustomMap.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.Maps;
+
+namespace PathMapper
+{
+    public class CustomMap : Map
+    {
+
+        public List<Position> PathCoordinates { get; set; }
+
+        public CustomMap()
+        {
+            PathCoordinates = new List<Position>();
+        }
+
+    }
+}

--- a/app/PathMapper/PathMapper/PathMapper/MapPage.cs
+++ b/app/PathMapper/PathMapper/PathMapper/MapPage.cs
@@ -11,7 +11,11 @@ namespace PathMapper
 
         public MapPage()
         {
-            map = new Map { HeightRequest = 100, WidthRequest = 960, VerticalOptions = LayoutOptions.FillAndExpand };
+            map = new Map {
+                IsShowingUser = true,
+                HeightRequest = 100,
+                WidthRequest = 960,
+                VerticalOptions = LayoutOptions.FillAndExpand };
 
             //var gardensPosition = new Position(-45.856621, 170.518691); //Botanic Gardens Information Center
             // Position doesn't seem to work in scope with the FromCenterAndRadius Method, it might have to be global

--- a/app/PathMapper/PathMapper/PathMapper/MapPage.cs
+++ b/app/PathMapper/PathMapper/PathMapper/MapPage.cs
@@ -8,11 +8,12 @@ namespace PathMapper
     public class MapPage : ContentPage
     {
         Map map;
-
+       
         public MapPage()
         {
             map = new Map {
                 IsShowingUser = true,
+                
                 HeightRequest = 100,
                 WidthRequest = 960,
                 VerticalOptions = LayoutOptions.FillAndExpand };

--- a/app/PathMapper/PathMapper/PathMapper/OverlayPath.cs
+++ b/app/PathMapper/PathMapper/PathMapper/OverlayPath.cs
@@ -41,7 +41,7 @@ namespace PathMapper
             customMap.PathCoordinates.Add(new Position(-45.856636, 170.521193));
             customMap.PathCoordinates.Add(new Position(-45.856691, 170.521513));
 
-            customMap.MoveToRegion(MapSpan.FromCenterAndRadius(new Position(-45.856542, 170.518708), Distance.FromMiles(1.0)));
+            customMap.MoveToRegion(MapSpan.FromCenterAndRadius(new Position(-45.857086, 170.519698), Distance.FromMiles(0.1)));
             Content = customMap;
         }
 

--- a/app/PathMapper/PathMapper/PathMapper/OverlayPath.cs
+++ b/app/PathMapper/PathMapper/PathMapper/OverlayPath.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+using Xamarin.Forms.Maps;
+
+namespace PathMapper
+{
+    public class OverlayPath : ContentPage
+    {
+
+       
+
+        public OverlayPath()
+        {
+            var customMap = new CustomMap
+            {
+                IsShowingUser = true,
+                MapType = MapType.Street,
+                HeightRequest = 100,
+                WidthRequest = 960,
+                VerticalOptions = LayoutOptions.FillAndExpand
+            };
+
+            customMap.PathCoordinates.Add(new Position(-45.856542, 170.518708));
+            customMap.PathCoordinates.Add(new Position(-45.856640, 170.518893));
+            customMap.PathCoordinates.Add(new Position(-45.856692, 170.518966));
+            customMap.PathCoordinates.Add(new Position(-45.856784, 170.519006));
+            customMap.PathCoordinates.Add(new Position(-45.856954, 170.519076));
+            customMap.PathCoordinates.Add(new Position(-45.857084, 170.519228));
+            customMap.PathCoordinates.Add(new Position(-45.857224, 170.519456));
+            customMap.PathCoordinates.Add(new Position(-45.857086, 170.519698));
+            customMap.PathCoordinates.Add(new Position(-45.856932, 170.520177));
+            customMap.PathCoordinates.Add(new Position(-45.856828, 170.520344));
+            customMap.PathCoordinates.Add(new Position(-45.856652, 170.520521));
+            customMap.PathCoordinates.Add(new Position(-45.856586, 170.520728));
+            customMap.PathCoordinates.Add(new Position(-45.856438, 170.521035));
+            customMap.PathCoordinates.Add(new Position(-45.856405, 170.521318));
+            customMap.PathCoordinates.Add(new Position(-45.856636, 170.521193));
+            customMap.PathCoordinates.Add(new Position(-45.856691, 170.521513));
+
+            customMap.MoveToRegion(MapSpan.FromCenterAndRadius(new Position(-45.856542, 170.518708), Distance.FromMiles(1.0)));
+            Content = customMap;
+        }
+
+    }
+}

--- a/app/PathMapper/PathMapper/PathMapper/PathMapper.csproj
+++ b/app/PathMapper/PathMapper/PathMapper/PathMapper.csproj
@@ -45,6 +45,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Mono.Android">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\MonoAndroid\v6.0\Mono.Android.dll</HintPath>
+    </Reference>
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.Forms.2.2.0.31\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
       <Private>True</Private>

--- a/app/PathMapper/PathMapper/PathMapper/PathMapper.csproj
+++ b/app/PathMapper/PathMapper/PathMapper/PathMapper.csproj
@@ -37,7 +37,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="App.cs" />
+    <Compile Include="CustomMap.cs" />
     <Compile Include="MapPage.cs" />
+    <Compile Include="OverlayPath.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/app/PathMapper/PathMapper/PathMapper/Properties/AssemblyInfo.cs
+++ b/app/PathMapper/PathMapper/PathMapper/Properties/AssemblyInfo.cs
@@ -2,6 +2,8 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Android;
+using Android.App;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -28,3 +30,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: UsesPermission(Manifest.Permission.Internet)]
+[assembly: UsesPermission(Manifest.Permission.AccessFineLocation)]
+[assembly: UsesPermission(Manifest.Permission.AccessCoarseLocation)]


### PR DESCRIPTION
Allows both maps to go to users device location.
New Tab with Path showing on map.
End of path proves custom tracks can be made to accommodate  tracks current not shown on google maps.
Requires renderer class for Android and iOS.
Not tested on iOS.